### PR TITLE
Added the beginnings of some Cypress tests for Splunk

### DIFF
--- a/tests/cypress/README.md
+++ b/tests/cypress/README.md
@@ -1,0 +1,73 @@
+
+
+# Set up
+
+Install the Cypress test software, see the instructions at
+<https://docs.cypress.io/guides/getting-started/installing-cypress.html>
+
+Install the Docker image for Splunk and the Censys plug-in:
+
+1.  Get the Docker image: <https://hub.docker.com/r/splunk/splunk/>
+2.  Start Splunk
+
+        docker run -d -p 8000:8000 -e "SPLUNK_START_ARGS=--accept-license" -e "SPLUNK_PASSWORD=PaSSWorD_FoR_SpLuNk" --name splunk splunk/splunk:latest
+3.  Go to <http://localhost:8000> and log in as `admin` using the
+    password specified on the `docker run` command line
+4.  Go to <https://app.censys.io/docs/splunk-integration/> and
+    follow the instructions.
+
+Set the environment variable `CYPRESS_SPLUNK_PASSWORD` to what you
+set the password to on the `docker run` line.  Note that this
+password will be printed to the Cypress console when the tests run,
+so don't use a secret password (this should only ever be running on
+your laptop and not exposed to any networks, so this shouldn't be a
+security risk, but be aware).
+
+
+# Running the tests
+
+Go into the directory with the `cypress.json` file in it and type:
+
+    npx cypress run
+
+If you want to watch the tests run, type:
+
+    npx cypress run --headed
+
+or
+
+    npx cypress run --browser chrome
+
+
+# Notes
+
+-   The tests are in `e2e/censys_app_spec.js`
+
+-   The tests are all in one test block so the test user can stay
+    logged in; if you make a new test block, you will need to log in
+    again
+
+-   Splunk isn't well structured for automated testing, so there is
+    some fragility in the tests because they rely on DOM elements that
+    could change; if a test fails because an element can't be found,
+    you'll have to update it to match what the current version of
+    Splunk shows
+
+
+# Things to do
+
+The initial commit of this is a simple skeleton with lots of room
+for improvement.
+
+Some specific areas of improvement are:
+
+-   [ ] the login code could be pulled out into a utility library
+
+-   [ ] the tests could include the installation process and start
+    from an unmodified Splunk Docker container
+
+-   [ ] the tests could populate Splunk with known data then confirm
+    that the reports are correct
+
+-   [ ] the tests could start the Docker container so that the set-up
+    was automated

--- a/tests/cypress/cypress.json
+++ b/tests/cypress/cypress.json
@@ -1,0 +1,11 @@
+{
+  "baseUrl": "http://localhost:8000/",
+  "integrationFolder": "./e2e",
+  "viewportWidth": 1400,
+  "viewportHeight": 900,
+  "reporter": "junit",
+  "defaultCommandTimeout": 16000,
+  "reporterOptions": {
+    "mochaFile": "./test-results/results-[hash].xml"
+  }
+}

--- a/tests/cypress/cypress/fixtures/example.json
+++ b/tests/cypress/cypress/fixtures/example.json
@@ -1,0 +1,5 @@
+{
+  "name": "Using fixtures to represent data",
+  "email": "hello@cypress.io",
+  "body": "Fixtures are a great way to mock data for responses to routes"
+}

--- a/tests/cypress/cypress/plugins/index.js
+++ b/tests/cypress/cypress/plugins/index.js
@@ -1,0 +1,21 @@
+/// <reference types="cypress" />
+// ***********************************************************
+// This example plugins/index.js can be used to load plugins
+//
+// You can change the location of this file or turn off loading
+// the plugins file with the 'pluginsFile' configuration option.
+//
+// You can read more here:
+// https://on.cypress.io/plugins-guide
+// ***********************************************************
+
+// This function is called when a project is opened or re-opened (e.g. due to
+// the project's config changing)
+
+/**
+ * @type {Cypress.PluginConfig}
+ */
+module.exports = (on, config) => {
+  // `on` is used to hook into various events Cypress emits
+  // `config` is the resolved Cypress config
+}

--- a/tests/cypress/cypress/support/commands.js
+++ b/tests/cypress/cypress/support/commands.js
@@ -1,0 +1,25 @@
+// ***********************************************
+// This example commands.js shows you how to
+// create various custom commands and overwrite
+// existing commands.
+//
+// For more comprehensive examples of custom
+// commands please read more here:
+// https://on.cypress.io/custom-commands
+// ***********************************************
+//
+//
+// -- This is a parent command --
+// Cypress.Commands.add("login", (email, password) => { ... })
+//
+//
+// -- This is a child command --
+// Cypress.Commands.add("drag", { prevSubject: 'element'}, (subject, options) => { ... })
+//
+//
+// -- This is a dual command --
+// Cypress.Commands.add("dismiss", { prevSubject: 'optional'}, (subject, options) => { ... })
+//
+//
+// -- This will overwrite an existing command --
+// Cypress.Commands.overwrite("visit", (originalFn, url, options) => { ... })

--- a/tests/cypress/cypress/support/index.js
+++ b/tests/cypress/cypress/support/index.js
@@ -1,0 +1,20 @@
+// ***********************************************************
+// This example support/index.js is processed and
+// loaded automatically before your test files.
+//
+// This is a great place to put global configuration and
+// behavior that modifies Cypress.
+//
+// You can change the location of this file or turn off
+// automatically serving support files with the
+// 'supportFile' configuration option.
+//
+// You can read more here:
+// https://on.cypress.io/configuration
+// ***********************************************************
+
+// Import commands.js using ES2015 syntax:
+import './commands'
+
+// Alternatively you can use CommonJS syntax:
+// require('./commands')

--- a/tests/cypress/e2e/censys_app_spec.js
+++ b/tests/cypress/e2e/censys_app_spec.js
@@ -1,0 +1,32 @@
+
+describe('Is the Censys App Installed', () => {
+
+    it('should find the dashboards', () => {
+        // the shell environment variable to set is CYPRESS_SPLUNK_PASSWORD
+        const password = Cypress.env('SPLUNK_PASSWORD')
+        expect(password, 'password was set').to.be.a('string').and.not.be.empty
+
+        // log in
+        cy.visit("http://localhost:8000/");
+        cy.url().should('include', 'account/login')
+        cy.get('input[id="username"]').type("admin").get('input[id="password"]').type(password)
+        cy.get(".loginForm").get(".splButton-primary.btn.btn-primary").first().click()
+
+        // click the Censys app button
+        cy.get('a[aria-label="Censys"]').click()
+
+        // click the dashboards link
+        cy.get('a[Title="Dashboards"]').click()
+
+        // make sure that the two dashboards we expect are present
+        cy.contains("Censys Enterprise")
+        cy.contains("Events by type for past day")
+
+        // open the Censys Enterprise Dashboard
+        cy.get('a[title="Censys Enterprise"]').click()
+        cy.contains("New CVEs for Hosts")
+
+    });
+
+
+})


### PR DESCRIPTION
These are the beginnings of Cypress tests for Splunk; hopefully it is enough to build on.

There is some Cypress boiler-plate in here that is nice to have around, but the two important files are `README.md` and `cypress_app_spec.js`.