### PR TITLE
Tcomesana cs/iip 19410 3

### DIFF
--- a/packages/Splunk_TA_censys/bin/censys_asm_hosts_command.py
+++ b/packages/Splunk_TA_censys/bin/censys_asm_hosts_command.py
@@ -25,6 +25,7 @@
 
 import json
 import sys
+import threading
 import time
 import traceback
 from concurrent.futures import ThreadPoolExecutor
@@ -52,6 +53,11 @@ MAX_BATCH_SIZE = 100
 MAX_BATCH_DELAY_SEC = 60
 # Piped mode: max events buffered in memory (fail fast if upstream returns more).
 MAX_PIPELINE_RECORDS = 50_000
+# Per-request timeout for GET .../v1/assets/hosts/{ip} (connect + read, seconds).
+ASM_HOST_GET_TIMEOUT_SEC = 5
+
+# ThreadPoolExecutor workers may log fetch failures concurrently; keep stderr lines intact.
+_FETCH_ERR_LOG_LOCK = threading.Lock()
 
 
 def _materialize_records_bounded(records: Iterable[dict]) -> List[dict]:
@@ -136,8 +142,10 @@ def _report_fetch_error(cmd_name: str, ip: str, exc: BaseException) -> None:
     detail = str(exc)
     if isinstance(exc, requests.HTTPError) and exc.response is not None:
         detail = f"HTTP {exc.response.status_code} {detail}"
-    sys.stderr.write(f"{cmd_name} fetch error: ip={ip!r} {detail}\n")
-    sys.stderr.flush()
+    line = f"{cmd_name} fetch error: ip={ip!r} {detail}\n"
+    with _FETCH_ERR_LOG_LOCK:
+        sys.stderr.write(line)
+        sys.stderr.flush()
 
 
 @Configuration()
@@ -211,7 +219,7 @@ class CensysAsmHostsCommand(StreamingCommand):
             r = requests.get(
                 url,
                 headers=headers,
-                timeout=30,
+                timeout=ASM_HOST_GET_TIMEOUT_SEC,
                 proxies=self._requests_proxies(),
             )
             r.raise_for_status()

--- a/packages/Splunk_TA_censys/bin/censys_asm_hosts_command.py
+++ b/packages/Splunk_TA_censys/bin/censys_asm_hosts_command.py
@@ -19,6 +19,7 @@
 #     Optional throttling when piped (defaults batch_size=20 batch_delay=10):
 #       batch_size 1–100 — max parallel ASM GETs per batch; use 1 for strictly sequential batches.
 #       batch_delay 0–60 — whole seconds to sleep after each batch; 0 = no sleep.
+#     Optional proxy= for v1/assets/hosts GETs (e.g. http://host:port); same URL used for http/https.
 #     Each distinct IP causes at most one ASM host GET per search (piped or ip= list).
 #     Piped input is capped (MAX_PIPELINE_RECORDS) so the command does not buffer unbounded rows.
 
@@ -144,6 +145,8 @@ class CensysAsmHostsCommand(StreamingCommand):
     """
     Fetch host asset(s) from Censys ASM by IP (GET .../v1/assets/hosts/{ip}).
 
+    Optional proxy= forwards those GETs through the given proxy URL.
+
     Not piped + ip=: | censysasmhosts ip="..."  →  new events per host.
     Not piped, no ip=, empty upstream →  zero rows (not an error).
     Piped: | ... | censysasmhosts →  enrich each row (seed, host_ip only).
@@ -176,8 +179,20 @@ class CensysAsmHostsCommand(StreamingCommand):
             % (0, MAX_BATCH_DELAY_SEC, DEFAULT_BATCH_DELAY)
         ),
     )
+    proxy = Option(
+        doc=(
+            "Optional proxy URL for ASM host GETs (e.g. http://proxy.example.com:8080). "
+            "Applied to https://app.censys.io/... requests; omit to use direct connections."
+        ),
+    )
 
     # --- Shared: HTTP + JSON fetch (both modes) ---
+
+    def _requests_proxies(self) -> Optional[Dict[str, str]]:
+        if _is_blank(self.proxy):
+            return None
+        url = str(self.proxy).strip()
+        return {"http": url, "https": url}
 
     def _request_headers(self) -> Dict[str, str]:
         api_key = get_asm_api_key(self.service)
@@ -193,7 +208,12 @@ class CensysAsmHostsCommand(StreamingCommand):
             return None, True
         url = f"{BASE_URL}/v1/assets/hosts/{ip}"
         try:
-            r = requests.get(url, headers=headers, timeout=30)
+            r = requests.get(
+                url,
+                headers=headers,
+                timeout=30,
+                proxies=self._requests_proxies(),
+            )
             r.raise_for_status()
             return r.json(), False
         except requests.RequestException as e:

--- a/packages/Splunk_TA_censys/default/commands.conf
+++ b/packages/Splunk_TA_censys/default/commands.conf
@@ -1,4 +1,4 @@
-# Fetch Censys ASM host asset(s) by IP. Piped: ip_field= batch_size= batch_delay= (defaults 20 / 10). Not piped: ip= (comma-separated).
+# Fetch Censys ASM host asset(s) by IP. Piped: ip_field= batch_size= batch_delay= (defaults 20 / 10). Not piped: ip= (comma-separated). Optional proxy= for outbound GETs.
 
 [censysasmhosts]
 filename = censys_asm_hosts_command.py

--- a/scripts/dev_fake_https_proxy.py
+++ b/scripts/dev_fake_https_proxy.py
@@ -1,0 +1,148 @@
+#!/usr/bin/env python3
+"""Tiny HTTP forward proxy for local testing (CONNECT tunneling).
+
+``requests`` to ``https://`` sends::
+
+    CONNECT host:443 HTTP/1.1
+
+We connect to ``host:port``, reply ``200 Connection established``, then relay
+raw bytes both ways so TLS passes through to the real server (e.g. Censys).
+
+Usage::
+
+    python3 scripts/dev_fake_https_proxy.py           # default 127.0.0.1:8899
+    python3 scripts/dev_fake_https_proxy.py 9999
+
+Optional: only log and return 502 (no upstream)::
+
+    python3 scripts/dev_fake_https_proxy.py --stub-502
+
+In the Censys add-on **Configuration → Proxy**, enable proxy; host ``127.0.0.1``,
+port ``8899`` (or your chosen port), type ``http``.
+"""
+import socket
+import sys
+import threading
+from typing import Optional, Tuple
+
+
+def _parse_connect_target(first_line: bytes) -> Optional[Tuple[str, int]]:
+    # CONNECT app.censys.io:443 HTTP/1.1
+    parts = first_line.split()
+    if len(parts) < 2:
+        return None
+    target = parts[1].decode("utf-8", errors="replace")
+    if ":" in target:
+        host, port_s = target.rsplit(":", 1)
+        try:
+            return host, int(port_s)
+        except ValueError:
+            return None
+    return target, 443
+
+
+def _pipe(src: socket.socket, dst: socket.socket) -> None:
+    try:
+        while True:
+            data = src.recv(65536)
+            if not data:
+                break
+            dst.sendall(data)
+    except OSError:
+        pass
+    try:
+        dst.shutdown(socket.SHUT_WR)
+    except OSError:
+        pass
+
+
+def _handle(client: socket.socket, addr: tuple, stub_502: bool) -> None:
+    remote: Optional[socket.socket] = None
+    try:
+        buf = b""
+        while b"\r\n\r\n" not in buf and len(buf) < 65536:
+            chunk = client.recv(8192)
+            if not chunk:
+                return
+            buf += chunk
+
+        first_line = buf.split(b"\r\n", 1)[0]
+        print(f"{addr[0]}:{addr[1]} {first_line.decode('utf-8', errors='replace')}", flush=True)
+
+        if not first_line.upper().startswith(b"CONNECT"):
+            client.sendall(
+                b"HTTP/1.1 501 Not Implemented\r\nContent-Length: 0\r\nConnection: close\r\n\r\n"
+            )
+            return
+
+        if stub_502:
+            client.sendall(
+                b"HTTP/1.1 502 Bad Gateway\r\nContent-Length: 0\r\nConnection: close\r\n\r\n"
+            )
+            return
+
+        parsed = _parse_connect_target(first_line)
+        if not parsed:
+            client.sendall(
+                b"HTTP/1.1 400 Bad Request\r\nContent-Length: 0\r\nConnection: close\r\n\r\n"
+            )
+            return
+
+        host, port = parsed
+        try:
+            remote = socket.create_connection((host, port), timeout=60)
+        except OSError as e:
+            print(f"  upstream connect failed {host}:{port} ({e})", flush=True)
+            client.sendall(
+                b"HTTP/1.1 502 Bad Gateway\r\nContent-Length: 0\r\nConnection: close\r\n\r\n"
+            )
+            return
+
+        client.sendall(b"HTTP/1.1 200 Connection established\r\n\r\n")
+
+        header_end = buf.index(b"\r\n\r\n") + 4
+        extra = buf[header_end:]
+        if extra:
+            remote.sendall(extra)
+
+        t1 = threading.Thread(target=_pipe, args=(client, remote), daemon=True)
+        t2 = threading.Thread(target=_pipe, args=(remote, client), daemon=True)
+        t1.start()
+        t2.start()
+        t1.join()
+        t2.join()
+    finally:
+        try:
+            client.close()
+        except OSError:
+            pass
+        if remote is not None:
+            try:
+                remote.close()
+            except OSError:
+                pass
+
+
+def main() -> None:
+    args = [a for a in sys.argv[1:] if a]
+    stub_502 = False
+    if "--stub-502" in args:
+        stub_502 = True
+        args = [a for a in args if a != "--stub-502"]
+    port = int(args[0]) if args else 8899
+    host = "127.0.0.1"
+    sock = socket.socket(socket.AF_INET, socket.SOCK_STREAM)
+    sock.setsockopt(socket.SOL_SOCKET, socket.SO_REUSEADDR, 1)
+    sock.bind((host, port))
+    sock.listen(32)
+    mode = "CONNECT → tunnel to upstream" if not stub_502 else "CONNECT → 502 only"
+    print(f"dev HTTPS proxy on http://{host}:{port} ({mode})", flush=True)
+    while True:
+        conn, addr = sock.accept()
+        threading.Thread(
+            target=_handle, args=(conn, addr, stub_502), daemon=True
+        ).start()
+
+
+if __name__ == "__main__":
+    main()


### PR DESCRIPTION
…ts command.

Changes:
1. Include proxy parameter for censysasmhosts to allow host requests to go through a proxy before being forwarded to retrieve host information.

How to Test:
1. Go to the Censys ASM Add On.
2. Go to Search.
3. Include proxy that is not running and no results will be returned. Also, the logs will show and error.
`| censysasmhosts ip="{IP Address}" proxy="http://127.0.0.1:8899"`

<img width="1919" height="383" alt="image" src="https://github.com/user-attachments/assets/8b893289-bd08-4766-b0a5-48a3686e85b8" />

4. Setup a fake proxy by running the following from the root:
`python3 /Users/thomascomesana/Source/censys-splunk/scripts/dev_fake_https_proxy.py; `

5. Run the command with the proxy again, and you should see results:
`| censysasmhosts ip="{IP Address}" proxy="http://127.0.0.1:8899"`

<img width="1919" height="581" alt="image" src="https://github.com/user-attachments/assets/023a8951-0032-473e-9edb-ef311061b59c" />

6. Try without a proxy, and you should see results:
`| censysasmhosts ip="{IP Address}"`

<img width="1916" height="581" alt="image" src="https://github.com/user-attachments/assets/f4521745-bf47-4fa7-a7f7-805e6032f212" />

7. Try running with "Generate Logbook IP to Seed Lookup" and "Generate Risk Instance IP to Seed Lookup" saved searches.